### PR TITLE
 define new enum for camera preview aspect/stretching based on the XF and handle using the enum in Android when using Camera2 API

### DIFF
--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/CameraPreviewControl.xaml.cs
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/CameraPreviewControl.xaml.cs
@@ -26,7 +26,7 @@ namespace BuildIt.Forms.Controls
             BindableProperty.Create(nameof(EnableContinuousAutoFocus), typeof(bool), typeof(CameraPreviewControl), false);
 
         public static readonly BindableProperty AspectProperty =
-            BindableProperty.Create(nameof(Aspect), typeof(Aspect), typeof(CameraPreviewControl), default(Aspect));
+            BindableProperty.Create(nameof(Aspect), typeof(CameraPreviewAspect), typeof(CameraPreviewControl), default(CameraPreviewAspect));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CameraPreviewControl"/> class.
@@ -80,9 +80,9 @@ namespace BuildIt.Forms.Controls
             set => SetValue(EnableContinuousAutoFocusProperty, value);
         }
 
-        public Aspect Aspect
+        public CameraPreviewAspect Aspect
         {
-            get => (Aspect)GetValue(AspectProperty);
+            get => (CameraPreviewAspect)GetValue(AspectProperty);
             set => SetValue(AspectProperty, value);
         }
 

--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/Enums.cs
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/Enums.cs
@@ -25,4 +25,22 @@
         /// </summary>
         Manual
     }
+
+    /// <summary>
+    /// Defines the camera preview is displayed
+    /// </summary>
+    public enum CameraPreviewAspect
+    {
+        /// <summary>
+        /// Scale the preview to fit the view. Some parts may be left empty (letter boxing)
+        /// </summary>
+        // Note: aspect fit is the default (as opposed to none) to be consistent with how the
+        // Aspect enum is defined in Xamarin Forms to reduce cognitive load of devs
+        AspectFit,
+
+        /// <summary>
+        /// Scale the preview so it exactly fills the view. Scaling may not be in uniform in X and Y
+        /// </summary>
+        Fill
+    }
 }

--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Android/AutoFitTextureView.cs
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Android/AutoFitTextureView.cs
@@ -9,6 +9,7 @@ namespace BuildIt.Forms.Controls.Platforms.Android
     {
         private int ratioWidth = 0;
         private int ratioHeight = 0;
+        private CameraPreviewAspect aspect;
 
         public AutoFitTextureView(Context context)
             : this(context, null)
@@ -25,13 +26,14 @@ namespace BuildIt.Forms.Controls.Platforms.Android
         {
         }
 
-        public void SetAspectRatio(int width, int height)
+        public void SetAspectRatio(CameraPreviewAspect aspect, int width, int height)
         {
             if (width == 0 || height == 0)
             {
                 throw new ArgumentException("Size cannot be negative.");
             }
 
+            this.aspect = aspect;
             ratioWidth = width;
             ratioHeight = height;
             RequestLayout();
@@ -45,17 +47,27 @@ namespace BuildIt.Forms.Controls.Platforms.Android
             if (ratioWidth == 0 || ratioHeight == 0)
             {
                 SetMeasuredDimension(width, height);
+                return;
             }
-            else
+
+            switch (aspect)
             {
-                if (width < (float)height * ratioWidth / (float)ratioHeight)
-                {
-                    SetMeasuredDimension(width, width * ratioHeight / ratioWidth);
-                }
-                else
-                {
-                    SetMeasuredDimension(height * ratioWidth / ratioHeight, height);
-                }
+                case CameraPreviewAspect.AspectFit:
+                    if (width < (float)height * ratioWidth / (float)ratioHeight)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"bui:2 {width}, {width * ratioHeight / ratioWidth}");
+                        SetMeasuredDimension(width, width * ratioHeight / ratioWidth);
+                    }
+                    else
+                    {
+                        SetMeasuredDimension(height * ratioWidth / ratioHeight, height);
+                    }
+
+                    break;
+
+                case CameraPreviewAspect.Fill:
+                    SetMeasuredDimension(width, height);
+                    break;
             }
         }
     }

--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Android/CameraPreviewControlRenderer.cs
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Android/CameraPreviewControlRenderer.cs
@@ -199,12 +199,20 @@ namespace BuildIt.Forms.Controls.Platforms.Android
 
         public void OnActivityPaused(Activity activity)
         {
-            CloseCamera();
-            StopBackgroundThread();
+            if (useCamera2Api)
+            {
+                CloseCamera();
+                StopBackgroundThread();
+            }
         }
 
         public void OnActivityResumed(Activity activity)
         {
+            if (!useCamera2Api)
+            {
+                return;
+            }
+
             StartBackgroundThread();
             if (textureView == null)
             {
@@ -983,17 +991,7 @@ namespace BuildIt.Forms.Controls.Platforms.Android
                     // bus' bandwidth limitation, resulting in gorgeous previews but the storage of
                     // garbage capture data.
                     previewSize = ChooseOptimalSize(map.GetOutputSizes(Class.FromType(typeof(SurfaceTexture))), rotatedPreviewWidth, rotatedPreviewHeight, maxPreviewWidth, maxPreviewHeight, largest);
-
-                    // We fit the aspect ratio of TextureView to the size of preview we picked.
-                    var orientation = Resources.Configuration.Orientation;
-                    if (orientation == global::Android.Content.Res.Orientation.Landscape)
-                    {
-                        textureView.SetAspectRatio(previewSize.Width, previewSize.Height);
-                    }
-                    else
-                    {
-                        textureView.SetAspectRatio(previewSize.Height, previewSize.Width);
-                    }
+                    SetTextureAspectRatio();
 
                     // Check if the flash is supported.
                     var available = (Java.Lang.Boolean)characteristics.Get(CameraCharacteristics.FlashInfoAvailable);
@@ -1017,6 +1015,20 @@ namespace BuildIt.Forms.Controls.Platforms.Android
             catch (NullPointerException e)
             {
                 e.PrintStackTrace();
+            }
+        }
+
+        private void SetTextureAspectRatio()
+        {
+            // We fit the aspect ratio of TextureView to the size of preview we picked.
+            var orientation = Resources.Configuration.Orientation;
+            if (orientation == global::Android.Content.Res.Orientation.Landscape)
+            {
+                textureView.SetAspectRatio(cameraPreviewControl.Aspect, previewSize.Width, previewSize.Height);
+            }
+            else
+            {
+                textureView.SetAspectRatio(cameraPreviewControl.Aspect, previewSize.Height, previewSize.Width);
             }
         }
 

--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Ios/CameraPreviewControlRenderer.cs
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Ios/CameraPreviewControlRenderer.cs
@@ -297,15 +297,11 @@ namespace BuildIt.Forms.Controls.Platforms.Ios
 
             switch (cameraPreviewControl.Aspect)
             {
-                case Aspect.AspectFit:
+                case CameraPreviewAspect.AspectFit:
                     videoPreviewLayer.VideoGravity = AVLayerVideoGravity.ResizeAspect;
                     break;
 
-                case Aspect.AspectFill:
-                    videoPreviewLayer.VideoGravity = AVLayerVideoGravity.ResizeAspectFill;
-                    break;
-
-                case Aspect.Fill:
+                case CameraPreviewAspect.Fill:
                     videoPreviewLayer.VideoGravity = AVLayerVideoGravity.Resize;
                     break;
             }

--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Uap/CameraPreviewControlRenderer.cs
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/Platforms/Uap/CameraPreviewControlRenderer.cs
@@ -169,13 +169,10 @@ namespace BuildIt.Forms.Controls.Platforms.Uap
         {
             switch (cameraPreviewControl.Aspect)
             {
-                case Aspect.AspectFit:
+                case CameraPreviewAspect.AspectFit:
                     captureElement.Stretch = Stretch.Uniform;
                     break;
-                case Aspect.AspectFill:
-                    captureElement.Stretch = Stretch.UniformToFill;
-                    break;
-                case Aspect.Fill:
+                case CameraPreviewAspect.Fill:
                     captureElement.Stretch = Stretch.Fill;
                     break;
             }

--- a/src/BuildIt.Forms/BuildIt.Forms.Controls/Resources/layout/CameraLayout.axml
+++ b/src/BuildIt.Forms/BuildIt.Forms.Controls/Resources/layout/CameraLayout.axml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:layout_weight="1">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
   <BuildIt.Forms.Controls.Platforms.Android.AutoFitTextureView
     android:id="@+id/autoFitTextureView"
-      android:layout_marginTop="-95dp"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content" />
 </FrameLayout>

--- a/src/BuildIt.ML/Samples/BuildIt.ML.Sample.UI/MainPage.xaml
+++ b/src/BuildIt.ML/Samples/BuildIt.ML.Sample.UI/MainPage.xaml
@@ -6,7 +6,7 @@
     <ContentPage.Content>
         <StackLayout>
             <controls:CameraPreviewControl x:Name="CameraPreviewControl"
-                                           IsVisible="False"
+                                           Aspect="Fill"
                                            PreferredCamera="Back"
                                             />
             <Label Text="{Binding Classifications, StringFormat='Classifications: {0}'}" />


### PR DESCRIPTION
This enum has been added so that we can remove AspectFill as it doesn't make much sense and won't work for Android where there's a list of sizes that can be used. A size that is too big can also cause issues with exceeding the bus' bandwidth limitations